### PR TITLE
Resolving TypeErrors when attempting to JSON serialize datetime objects

### DIFF
--- a/xlsx_inventory.py
+++ b/xlsx_inventory.py
@@ -42,7 +42,7 @@ def main():
         inventory = sheet_to_inventory(group_by_col=config['group_by_col'], hostname_col=config['hostname_col'],
                                        sheet=sheet)
         if args.list:
-            print(json.dumps(inventory, indent=4, sort_keys=True))
+            print(json.dumps(inventory, indent=4, sort_keys=True, default=str))
         if args.config:
             create_config(filename=args.file, group_by_col=args.group_by_col, hostname_col=args.hostname_col,
                           sheet=args.sheet)
@@ -50,7 +50,7 @@ def main():
             try:
                 print(json.dumps(
                     inventory['_meta']['hostvars'][args.host],
-                    indent=4, sort_keys=True))
+                    indent=4, sort_keys=True, default=str))
             except KeyError as e:
                 print('\033[91mHost "%s" not Found!\033[0m' % e)
                 print(e)


### PR DESCRIPTION
When using this tool on Excel data that had Date/Time fields, the script would error when attempting to JSON serialize the data.

The following error was generated:

```
Traceback (most recent call last):
  File "./xlsx_inventory.py", line 149, in <module>
    main()
  File "./xlsx_inventory.py", line 53, in main
    indent=4, sort_keys=True))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 250, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 209, in encode
    chunks = list(chunks)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: datetime.datetime(2018, 10, 31, 20, 18) is not JSON serializable

```
I added the "default=str" parameter to the json.dumps call around lines 44 and 53.

From https://docs.python.org/2/library/json.html
"If specified, default should be a function that gets called for objects that can’t otherwise be serialized"

This allows the datetime objects to be converted to strings, which is fairly accurate, and JSON serializable.